### PR TITLE
feat: add npm release workflows for TypeScript package

### DIFF
--- a/.github/workflows/typescript-npm-manual-release.yml
+++ b/.github/workflows/typescript-npm-manual-release.yml
@@ -1,0 +1,94 @@
+name: TypeScript NPM Manual Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: 'Version type (major, minor, patch)'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
+      pre_release:
+        description: 'Is this a pre-release?'
+        required: false
+        default: false
+        type: boolean
+      release_notes:
+        description: 'Release notes'
+        required: false
+        type: string
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+      
+      - name: Configure Git
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+      
+      - name: Install dependencies
+        run: |
+          cd typescript
+          npm ci
+      
+      - name: Build
+        run: |
+          cd typescript
+          npm run build
+      
+      - name: Update version and create tag
+        id: version
+        run: |
+          cd typescript
+          # Update version based on input
+          VERSION=$(npm version ${{ github.event.inputs.version_type }} --no-git-tag-version)
+          # Remove quotes from version string
+          VERSION="${VERSION//\"/}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          
+          # Commit package.json changes
+          git add package.json
+          git commit -m "chore: bump version to $VERSION"
+          
+          # Create a new tag
+          git tag -a "$VERSION" -m "Release $VERSION"
+          git push --follow-tags
+      
+      - name: Publish to npm
+        run: |
+          cd typescript
+          npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.version.outputs.version }}
+          name: Release ${{ steps.version.outputs.version }}
+          body: ${{ github.event.inputs.release_notes }}
+          prerelease: ${{ github.event.inputs.pre_release }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Notify success
+        run: |
+          echo "🎉 Successfully published version ${{ steps.version.outputs.version }} to npm!" 

--- a/.github/workflows/typescript-npm-release.yml
+++ b/.github/workflows/typescript-npm-release.yml
@@ -1,0 +1,65 @@
+name: TypeScript NPM Release
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+      
+      - name: Extract version from release
+        id: extract_version
+        run: |
+          RELEASE_TAG=${{ github.event.release.tag_name }}
+          # Remove 'v' prefix if present
+          VERSION=${RELEASE_TAG#v}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+      
+      - name: Install dependencies
+        run: |
+          cd typescript
+          npm ci
+      
+      - name: Build
+        run: |
+          cd typescript
+          npm run build
+      
+      - name: Update version
+        run: |
+          cd typescript
+          # Update package.json version to match the release
+          npm version ${{ steps.extract_version.outputs.version }} --no-git-tag-version
+      
+      - name: Publish to npm
+        run: |
+          cd typescript
+          npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      
+      - name: Create success comment
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `🎉 Successfully published version ${{ steps.extract_version.outputs.version }} to npm!`
+            }) 

--- a/.github/workflows/typescript-promote-canary.yml
+++ b/.github/workflows/typescript-promote-canary.yml
@@ -1,0 +1,127 @@
+name: Promote Canary to Stable
+
+on:
+  workflow_dispatch:
+    inputs:
+      canary_version:
+        description: 'Canary version to promote (e.g., 0.3.0-canary.20250404021914)'
+        required: true
+        type: string
+      release_type:
+        description: 'Release type'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
+          - same
+      release_notes:
+        description: 'Release notes'
+        required: false
+        type: string
+
+jobs:
+  promote-to-stable:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+      
+      - name: Configure Git
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+      
+      - name: Extract base version
+        id: extract_version
+        run: |
+          CANARY_VERSION="${{ github.event.inputs.canary_version }}"
+          # Extract base version (remove canary suffix)
+          BASE_VERSION=$(echo "$CANARY_VERSION" | sed -E 's/(-canary\.[0-9]+)$//')
+          echo "base_version=$BASE_VERSION" >> $GITHUB_OUTPUT
+      
+      - name: Download canary package
+        run: |
+          cd typescript
+          # Install the canary version to temporary directory
+          npm pack browserstate@${{ github.event.inputs.canary_version }} --pack-destination /tmp
+          
+          # Extract the package
+          tar -xzf /tmp/browserstate-*.tgz -C /tmp
+      
+      - name: Determine new version
+        id: new_version
+        run: |
+          BASE_VERSION="${{ steps.extract_version.outputs.base_version }}"
+          RELEASE_TYPE="${{ github.event.inputs.release_type }}"
+          
+          if [ "$RELEASE_TYPE" = "same" ]; then
+            # Use the same version without canary suffix
+            NEW_VERSION="$BASE_VERSION"
+          else
+            # Increment version according to release type
+            cd typescript
+            # First set version to base version
+            npm version "$BASE_VERSION" --no-git-tag-version
+            # Then increment according to release type
+            NEW_VERSION=$(npm version "$RELEASE_TYPE" --no-git-tag-version)
+            # Remove quotes
+            NEW_VERSION="${NEW_VERSION//\"/}"
+          fi
+          
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+      
+      - name: Update package.json
+        run: |
+          cd typescript
+          # Set the new version
+          npm version ${{ steps.new_version.outputs.new_version }} --no-git-tag-version
+          
+          # Commit changes
+          git add package.json
+          git commit -m "chore: release version ${{ steps.new_version.outputs.new_version }}"
+          
+          # Create tag
+          git tag -a "v${{ steps.new_version.outputs.new_version }}" -m "Release ${{ steps.new_version.outputs.new_version }}"
+          git push --follow-tags
+      
+      - name: Build
+        run: |
+          cd typescript
+          npm ci
+          npm run build
+      
+      - name: Publish to npm
+        run: |
+          cd typescript
+          npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ steps.new_version.outputs.new_version }}
+          name: Release ${{ steps.new_version.outputs.new_version }}
+          body: |
+            Promoted from canary version ${{ github.event.inputs.canary_version }}
+            
+            ${{ github.event.inputs.release_notes }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Notify success
+        run: |
+          echo "🎉 Successfully promoted canary version ${{ github.event.inputs.canary_version }} to stable version ${{ steps.new_version.outputs.new_version }}!" 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add GitHub Actions workflows for manual, automatic, and canary promotion npm releases of a TypeScript package.
> 
>   - **Workflows**:
>     - Adds `typescript-npm-manual-release.yml` for manual npm releases with inputs for version type, pre-release, and release notes.
>     - Adds `typescript-npm-release.yml` for automatic npm releases triggered by GitHub release creation.
>     - Adds `typescript-promote-canary.yml` for promoting canary versions to stable, with inputs for canary version, release type, and release notes.
>   - **Common Steps**:
>     - All workflows set up Node.js 20 and configure Git.
>     - All workflows build the TypeScript package and publish to npm with provenance.
>     - All workflows create a GitHub release and notify success.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=browserstate-org%2Fbrowserstate&utm_source=github&utm_medium=referral)<sup> for 324ed8cb623f29360ea8c560872214877052aab2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->