### PR TITLE
feat: add PyPI publishing option to GitHub Actions workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -140,8 +140,26 @@ jobs:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
+        set -e  # Exit immediately if a command exits with a non-zero status
         cd python
-        python -m twine upload dist/*
+        
+        # Verify distribution files exist
+        if [ ! "$(ls -A dist)" ]; then
+          echo "❌ Error: No distribution files found in dist/ directory"
+          exit 1
+        fi
+        
+        # Validate the package before uploading
+        echo "🔍 Validating the package before uploading..."
+        twine check dist/*
+        
+        # Upload to PyPI with proper error handling
+        echo "📦 Uploading to PyPI..."
+        if ! python -m twine upload dist/*; then
+          echo "❌ Failed to upload package to PyPI"
+          exit 1
+        fi
+        
         echo "🚀 Package published to PyPI successfully!"
     
     - name: Update installation instructions

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,4 +1,4 @@
-name: Python Package Version Bump and Build
+name: Python Package Version Bump, Build and Publish to PyPI
 
 on:
   workflow_dispatch:
@@ -16,6 +16,11 @@ on:
         description: 'Override version (leave empty to auto-increment)'
         required: false
         type: string
+      publish_to_pypi:
+        description: 'Publish to PyPI'
+        required: true
+        default: false
+        type: boolean
 
 jobs:
   deploy:
@@ -37,7 +42,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install build hatch semver wheel
+        pip install build hatch semver wheel twine
     
     - name: Set Git identity
       run: |
@@ -129,10 +134,28 @@ jobs:
           echo "Tag python-v${{ steps.version.outputs.new_version }} already exists, skipping tag creation"
         fi
     
+    - name: Publish to PyPI
+      if: ${{ github.event.inputs.publish_to_pypi == 'true' }}
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        cd python
+        python -m twine upload dist/*
+        echo "🚀 Package published to PyPI successfully!"
+    
     - name: Update installation instructions
       run: |
         echo "::notice::Python package version ${{ steps.version.outputs.new_version }} built successfully!"
         echo "::notice::Pull request created to update version in main branch"
-        echo "::notice::Installation Instructions:"
-        echo "::notice::pip install git+https://github.com/browserstate-org/browserstate@python-v${{ steps.version.outputs.new_version }}#subdirectory=python"
-        echo "::notice::uv pip install git+https://github.com/browserstate-org/browserstate@python-v${{ steps.version.outputs.new_version }}#subdirectory=python" 
+        
+        if [ "${{ github.event.inputs.publish_to_pypi }}" == "true" ]; then
+          echo "::notice::📦 Package published to PyPI!"
+          echo "::notice::Installation Instructions:"
+          echo "::notice::pip install browserstate==${{ steps.version.outputs.new_version }}"
+          echo "::notice::uv pip install browserstate==${{ steps.version.outputs.new_version }}"
+        else
+          echo "::notice::Installation Instructions from GitHub:"
+          echo "::notice::pip install git+https://github.com/browserstate-org/browserstate@python-v${{ steps.version.outputs.new_version }}#subdirectory=python"
+          echo "::notice::uv pip install git+https://github.com/browserstate-org/browserstate@python-v${{ steps.version.outputs.new_version }}#subdirectory=python"
+        fi 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds PyPI publishing option to GitHub Actions workflow with error handling and validation.
> 
>   - **Workflow Enhancements**:
>     - Adds `publish_to_pypi` input parameter to `.github/workflows/python-publish.yml` for controlling PyPI publishing.
>     - Updates workflow name to "Python Package Version Bump, Build and Publish to PyPI".
>   - **Dependencies**:
>     - Adds `twine` to the list of installed dependencies for package publishing.
>   - **Publishing Logic**:
>     - Adds `Publish to PyPI` step, conditional on `publish_to_pypi` being `true`, with error handling and validation using `twine`.
>     - Updates installation instructions based on whether the package is published to PyPI or GitHub.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=browserstate-org%2Fbrowserstate&utm_source=github&utm_medium=referral)<sup> for 2828280a2ae97a83a20a65f6f4a5d41c13a6a89d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->